### PR TITLE
Initiative show

### DIFF
--- a/client/templates/initiative/initiative.html
+++ b/client/templates/initiative/initiative.html
@@ -28,6 +28,8 @@
 
 <template name='initiativeShow'>
  {{#with initiative}}
+ <h1>{{title}}</h1>
+ <p>{{description}}</p>
   <div class="initiative col s12 m12">
     <div class="card small">
       <div class="card-image">

--- a/client/templates/initiative/initiative.html
+++ b/client/templates/initiative/initiative.html
@@ -13,6 +13,35 @@
         <a href="#" class="initiative--user-image">
           <img src="{{userImage}}" alt="" class="circle responsive-img user-photo">
         </a>
+        <a href="{{ pathFor 'initiative' }}">
+          <h2 class="card-title">{{title}}</h2>
+        </a>
+        <p>
+          {{description}}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<!-- show template -->
+
+<template name='initiativeShow'>
+ {{#with initiative}}
+  <div class="initiative col s12 m12">
+    <div class="card small">
+      <div class="card-image">
+        <a href="#">
+          <img src="{{image}}">
+        </a>
+      </div>
+      <div class="initiative--content">
+        <div class="votes">
+          <i class="mdi-action-favorite "></i> {{votes}}
+        </div>
+        <a href="#" class="initiative--user-image">
+          <img src="{{userImage}}" alt="" class="circle responsive-img user-photo">
+        </a>
         <a href="#">
           <h2 class="card-title">{{title}}</h2>
         </a>
@@ -22,4 +51,5 @@
       </div>
     </div>
   </div>
+  {{/with}}
 </template>

--- a/client/templates/initiative/initiative.js
+++ b/client/templates/initiative/initiative.js
@@ -18,3 +18,24 @@ Template.initiative.events({
     }    
   }
 });
+
+Template.initiativeShow.helpers({
+  image: function(){
+    return "https://placeimg.com/300/250/arch";
+  },
+  userImage: function(){
+    return "https://placeimg.com/60/60/people";
+  }
+});
+
+Template.initiativeShow.events({
+  'click .votes': function(e, tpl){
+    // TODO: restrict votes to 1 pr initiative
+    if(Meteor.userId()){
+      Initiatives.update(this._id, {$inc: {votes: 1}});
+      sAlert.info('Thanks for voting on: '+ this.title);
+    } else {
+      sAlert.error('Can only vote as logged in user');
+    }    
+  }
+});

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -5,8 +5,10 @@ Router.configure({
 //From what I can tell this has been depreciated
 //https://github.com/iron-meteor/iron-router/blob/739bcc1445db3ad6bf90bda4e0cab3203a0ae526/lib/router.js#L88
 Router.map(function() {
+  // initiative routes
   this.route('initiatives', {
     path: '/',
+    template: 'initiatives',
     data: {
       initiatives: function() {
         return Initiatives.find();
@@ -24,6 +26,7 @@ Router.map(function() {
     }
   });
 
+  // login routes
   this.route('login', {
     path: '/login',
     template: 'publicLogin'

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -14,6 +14,16 @@ Router.map(function() {
     }
   });
 
+  this.route('initiative', {
+    path: '/initiative/:_id',
+    template: 'initiativeShow',
+    data: {
+      initiative: function() {
+        return Initiatives.findOne({id: this._id});
+      }
+    }
+  });
+
   this.route('login', {
     path: '/login',
     template: 'publicLogin'

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -19,9 +19,9 @@ Router.map(function() {
   this.route('initiative', {
     path: '/initiative/:_id',
     template: 'initiativeShow',
-    data: {
-      initiative: function() {
-        return Initiatives.findOne({id: this._id});
+    data: function () {
+      return {
+        initiative: Initiatives.findOne(this.params._id)
       }
     }
   });

--- a/server/mock.js
+++ b/server/mock.js
@@ -11,7 +11,7 @@ if(Meteor.isServer) {
 
       mockData.forEach(function(item) {
         console.log("Inserting " + item.title);
-        item._id = new Meteor.Collection.ObjectID();
+       // item._id = new Meteor.Collection.ObjectID();
         Initiatives.insert(item);
       });
     }


### PR DESCRIPTION
Created a basic show page for a single initiative, along with the route for it. Template is in initiative.html, name initiativeShow. We could stick to camel case naming, ie initiativeEdit etc when we get to that.

I have also commented out 'item._id = new Meteor.Collection.ObjectID();' in mock.js, as it creates object literal IDs in the database, which doesn't play well with Iron Router. Meteor creates strings as IDs which is what we need. An object literal is the Mongo default, but not Meteor default (from what I can gather...)

Someone can look at the design for the show page.

https://trello.com/c/sj6pAfyl
