### PR TITLE
Make addComment more secure

### DIFF
--- a/client/templates/initiative/show/initiativeShow.js
+++ b/client/templates/initiative/show/initiativeShow.js
@@ -34,7 +34,7 @@ Template.initiativeCommenter.events({
 
     // Grab input, and current user.
     var input = template.find('input[name="comment"]');
-    Meteor.call("addComment", Meteor.userId(), this._id, input.value);
+    Meteor.call("addComment", this._id, input.value);
     input.value = "";
     sAlert.info('Thank you for your comment');
   }

--- a/server/methods.js
+++ b/server/methods.js
@@ -1,14 +1,13 @@
-if(Meteor.isServer) {
-  Meteor.startup(function() {
-    Meteor.methods({
-      addComment: function(userId, initiativeId, input) {
-        Meteor.users.update(userId, { $addToSet: { commentedOn: initiativeId } });
-        Initiatives.update(initiativeId, {$addToSet: {comments: {
-          createdBy: userId,
-          message: input,
-          createdAt: new Date()
-        }}});
-      }
-    })
+Meteor.startup(function() {
+  Meteor.methods({
+    addComment: function(initiativeId, input) {
+      var userId = Meteor.userId();
+      Meteor.users.update(userId, { $addToSet: { commentedOn: initiativeId } });
+      Initiatives.update(initiativeId, {$addToSet: {comments: {
+        createdBy: userId,
+        message: input,
+        createdAt: new Date()
+      }}});
+    }
   });
-}
+});


### PR DESCRIPTION
Remove unnecessary Meteor.isServer check. Change meteor method to use Meteor.userId instead of passing it into the method.
