### PR TITLE
Add facebook integration to Cherish.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .meteor/local
 .meteor/meteorite
+private/local-settings.json

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -28,3 +28,5 @@ sacha:spin
 multiply:iron-router-progress
 zeroasterisk:throttle
 percolate:synced-cron
+accounts-facebook
+service-configuration

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,4 +1,6 @@
 accounts-base@1.2.0
+accounts-facebook@1.0.4
+accounts-oauth@1.1.5
 accounts-password@1.1.1
 aldeed:template-extension@3.4.3
 autopublish@1.0.3
@@ -18,6 +20,7 @@ ddp@1.1.0
 deps@1.0.7
 ejson@1.0.6
 email@1.0.6
+facebook@1.2.0
 fastclick@1.0.3
 fourseven:scss@3.1.1
 geojson-utils@1.0.3
@@ -62,6 +65,8 @@ msavin:jetsetter@1.0.17
 msavin:mongol@1.0.97
 multiply:iron-router-progress@1.0.1
 npm-bcrypt@0.7.8_2
+oauth@1.1.4
+oauth2@1.1.3
 observe-sequence@1.0.6
 ordered-dict@1.0.3
 percolate:synced-cron@1.2.1

--- a/client/templates/initiative/show/initiativeShow.html
+++ b/client/templates/initiative/show/initiativeShow.html
@@ -28,7 +28,7 @@
     <ul class="collection">
       {{#each comments}}
         <li class="collection-item avatar">
-          <img src="{{getInitiativeAuthorImage}}" alt="" class="circle responsive-img user-photo">
+          <img src="{{getCommentAuthorImage}}" alt="avatar" class="circle responsive-img user-photo">
           <p class="comment-message left">{{message}}</p>
           <span class="comment-time right">{{getPrettyDate createdAt}}</span>
         </li>

--- a/client/templates/initiative/show/initiativeShow.js
+++ b/client/templates/initiative/show/initiativeShow.js
@@ -44,3 +44,14 @@ Template.initiativeCommenter.events({
     });
   }
 });
+
+Template.initiativeComments.helpers({
+  getCommentAuthorImage: function() {
+    var user = Users.findOne(this.createdBy);
+    if(user) {
+      return user.profile.avatarImg;
+    } else {
+      return '/images/placeholder-avatar.jpg';
+    }
+  }
+})

--- a/client/templates/login/login.html
+++ b/client/templates/login/login.html
@@ -3,21 +3,32 @@
     <form class="col s6 offset-s3 login-form">
       <h2>Login to Cherish</h2>
       <div class="row">
-        <div class="input-field col s12">
-          <input id="email" type="email" class="validate email-address-input">
-          <label for="email">Email</label>
+        <div class="row">
+          <div class="input-field col s12">
+            <input id="email" type="email" class="validate email-address-input">
+            <label for="email">Email</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="input-field col s12">
+            <input id="password" type="password" class="validate password-input">
+            <label for="password">Password</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col s12">
+            <button class="btn waves-effect waves-light" type="submit" name="action">Login</button>
+          </div>
         </div>
       </div>
       <div class="row">
-        <div class="input-field col s12">
-          <input id="password" type="password" class="validate password-input">
-          <label for="password">Password</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col s12">
-          <button class="btn waves-effect waves-light" type="submit" name="action">Login</button>
-        </div>
+        {{#if currentUser}}
+          {{currentUser.services.facebook.name}} -
+          {{currentUser.services.facebook.gender}}
+          <button id="logout">Logout</button>
+        {{else}}
+          <button id="facebook-login" class="btn waves-effect waves-light">Login with Facebook</button>
+        {{/if}}
       </div>
     </form>
   </div>

--- a/client/templates/login/login.js
+++ b/client/templates/login/login.js
@@ -43,5 +43,29 @@ Template.publicLogin.events({
         }
       });
     }
+  },
+
+  'click #facebook-login': function(event) {
+    event.preventDefault();
+    Meteor.loginWithFacebook({}, function(err){
+      if (err) {
+        if(!Meteor.settings.facebook) {
+          sAlert.error('Facebook authentication is not setup for this app.');;
+        } else {
+          sAlert.error('Facebook login failed for unknown reasons.');
+        }
+      } else {
+        Router.go('initiatives');
+      }
+    });
+  },
+
+  'click #logout': function(event) {
+    event.preventDefault();
+    Meteor.logout(function(err){
+      if (err) {
+        throw new Meteor.Error("Logout failed");
+      }
+    })
   }
 });

--- a/client/templates/nav/nav.js
+++ b/client/templates/nav/nav.js
@@ -9,6 +9,7 @@ Template.nav.events({
     e.preventDefault();
     Meteor.logout(function(){
       sAlert.info('Logged out succesfully');
+      Router.go('initiatives');
     });
   }
 })

--- a/server/config/socialConfig.js
+++ b/server/config/socialConfig.js
@@ -1,0 +1,17 @@
+configureFacebook = function(config) {
+  ServiceConfiguration.configurations.remove({
+    service: 'facebook'
+  });
+
+  ServiceConfiguration.configurations.insert({
+    service: 'facebook',
+    appId: config.appId,
+    secret: config.secret
+  });
+};
+
+var facebookConfig = Meteor.settings.facebook;
+if(facebookConfig) {
+  console.log('Facebook settings received', facebookConfig);
+  configureFacebook(facebookConfig);
+}

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,7 +1,12 @@
 Accounts.onCreateUser(function(options, user) {
   //send user email
   sendWelcomeEmail(options.email, "no-reply@cherish.com", options.email);
-  // create profile object
+
+  if(user.services.facebook) {
+    options.profile.avatarImg = "http://graph.facebook.com/" + user.services.facebook.id + "/picture/?type=large";
+  } else {
+    options.profile.avatarImg = "/images/placeholder-avatar.jpg";
+  }
   user.profile = options.profile ? options.profile : {};
   return user;
 });

--- a/server/methods.js
+++ b/server/methods.js
@@ -62,7 +62,7 @@ Meteor.startup(function() {
           createdBy: Meteor.userId(),
           createdAt: new Date(),
           category: category,
-          imageUrl: 'images/placeholder-initiative.jpg',
+          imageUrl: '/images/placeholder-initiative.jpg',
           comments: [],
           slug: slug,
           categorySlug: categorySlug,


### PR DESCRIPTION
- Add Login with Facebook option below normal login flow (needs UI improvement)
- Use Facebook name/profile pic where applicable throughout Cherish
- Use proper default avatars throughout Cherish for users who aren't logged in through Facebook

**NOTE**: Upon startup, Cherish will now load Facebook App integration config settings from `./private/local-settings.json`

If settings are not found, Facebook login will not work - and associated errors have been placed on the event for logging in with Facebook to tell the user so.

Since I'm not publishing my appId and secret to the repo, I'll deploy this to heroku so you can see it working.

If you want to set up your own Facebook App on your own Facebook account, you'll need to fill in the following in your own local `./private/local-settings.json' - which is ignored by git now.

```
{
  "mode": "prod",
  "facebook": {
    "appId": "foo",
    "secret": "bar"
  },
  "public": {
    "initiativeLimit": 5
  }
}
```
