### PR TITLE
created share buttons using share urls

### DIFF
--- a/client/templates/initiative/header/_initiativeHeader.sass
+++ b/client/templates/initiative/header/_initiativeHeader.sass
@@ -66,3 +66,10 @@
             border-bottom: 3px solid darken(#1e88e5, 30%)
           &:active
             border-bottom: none
+
+      .social-share-buttons
+        padding-top: 10px
+
+        a 
+          color: #fff
+          padding: 0 10px

--- a/client/templates/initiative/header/_initiativeHeader.sass
+++ b/client/templates/initiative/header/_initiativeHeader.sass
@@ -68,8 +68,16 @@
             border-bottom: none
 
       .social-share-buttons
-        padding-top: 10px
+        padding-top: 20px
 
         a 
+          border: 2px solid #fff
+          border-radius: 3px
           color: #fff
-          padding: 0 10px
+          padding: 10px
+          margin: 0 2px
+          transition: background-color 0.3s ease;
+
+          &:hover 
+            background: #fff
+            color: $primary-color

--- a/client/templates/initiative/header/initiativeHeader.js
+++ b/client/templates/initiative/header/initiativeHeader.js
@@ -3,4 +3,8 @@ Template.initiativeHeader.events({
     e.preventDefault();
     followUnfollow(this);
   }
-})
+});
+
+Template.registerHelper('getCurrentUrl', function() {
+  return window.location.href;
+});

--- a/client/templates/initiative/header/initiativeheader.html
+++ b/client/templates/initiative/header/initiativeheader.html
@@ -21,13 +21,13 @@
         {{/if}}
         <div class="social-share-buttons">
           
-          <a target="_blank" class="twitter-share-button" href="https://twitter.com/share?url={{getCurrentUrl}}&text={{title}}"><i class="material-icons tiny">reply</i> Twitter</a>
+          <a target="_blank" class="twitter-share-button" href="https://twitter.com/share?url={{getCurrentUrl}}&amp;text={{title}}"><i class="material-icons tiny">reply</i> Twitter</a>
 
           <a target="_blank" class="facebook-share-button" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]={{getCurrentUrl}}&amp;p[images]=http://cherish.meteor.com/images/placeholder-initiative.jpg&amp;p[title]={{title}}&amp;p[summary]={{description}}"><i class="material-icons tiny">reply</i> Facebook</a>
 
           <a target="_blank" class="google-share-button" href="https://plus.google.com/share?url={{getCurrentUrl}}"><i class="material-icons tiny">reply</i> Google+</a>
 
-          <a target="_blank" class="pinterest-share-button" href="https://pinterest.com/pin/create/bookmarklet/?media=http://cherish.meteor.com/images/placeholder-initiative.jpg&url={{getCurrentUrl}}&description={{description}}"><i class="material-icons tiny">reply</i> Pinterest</a>
+          <a target="_blank" class="pinterest-share-button" href="https://pinterest.com/pin/create/bookmarklet/?media=http://cherish.meteor.com/images/placeholder-initiative.jpg&amp;url={{getCurrentUrl}}&amp;description={{description}}"><i class="material-icons tiny">reply</i> Pinterest</a>
         </div>
       </div>
     </div>

--- a/client/templates/initiative/header/initiativeheader.html
+++ b/client/templates/initiative/header/initiativeheader.html
@@ -19,6 +19,16 @@
         </div>
         {{/unless}}
         {{/if}}
+        <div class="social-share-buttons">
+          
+          <a target="_blank" class="twitter-share-button" href="https://twitter.com/share?url={{getCurrentUrl}}&text={{title}}"><i class="material-icons tiny">reply</i> Twitter</a>
+
+          <a target="_blank" class="facebook-share-button" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]={{getCurrentUrl}}&amp;p[images]=http://cherish.meteor.com/images/placeholder-initiative.jpg&amp;p[title]={{title}}&amp;p[summary]={{description}}"><i class="material-icons tiny">reply</i> Facebook</a>
+
+          <a target="_blank" class="google-share-button" href="https://plus.google.com/share?url={{getCurrentUrl}}"><i class="material-icons tiny">reply</i> Google+</a>
+
+          <a target="_blank" class="pinterest-share-button" href="https://pinterest.com/pin/create/bookmarklet/?media=http://cherish.meteor.com/images/placeholder-initiative.jpg&url={{getCurrentUrl}}&description={{description}}"><i class="material-icons tiny">reply</i> Pinterest</a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Instead of using the standard tweet, like button etc which can have performance issues I created simple links to match the header are using the relevant share links which we can add in the title, link, description etc. There is no social media icons in materialize set so for now just used the reply icon. 

Thoughts on this layout or improvements 
